### PR TITLE
fix: 统一 CI 使用 pnpm 替代 npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,34 +25,34 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
+        cache: 'pnpm'
     
     - name: Install dependencies
-      run: npm ci
+      run: pnpm install
     
     - name: Initialize Stellar theme submodules
       run: |
         git submodule update --init --recursive
-        npm run themes:status
+        pnpm run themes:status
     
     - name: Validate Stellar theme configuration
-      run: npm run stellar:validate
+      run: pnpm run stellar:validate
     
     - name: Run tests
-      run: npm test
+      run: pnpm test
     
     - name: Lint check
-      run: npm run lint
+      run: pnpm run lint
     
     - name: Build test with Stellar theme
       run: |
-        npm run clean
-        npm run stellar:validate
+        pnpm run clean
+        pnpm run stellar:validate
         echo "🏗️ Building with Stellar theme (json_ld errors are expected and don't affect final output)..."
-        npm run build || echo "⚠️ Build completed with warnings (json_ld helper errors are known and don't affect functionality)"
+        pnpm run build || echo "⚠️ Build completed with warnings (json_ld helper errors are known and don't affect functionality)"
     
     - name: Check for broken links
-      run: npm run check-links || echo "⚠️ Link check completed with warnings"
+      run: pnpm run check-links || echo "⚠️ Link check completed with warnings"
 
   security-scan:
     runs-on: ubuntu-latest
@@ -66,16 +66,16 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20.x'
-        cache: 'npm'
+        cache: 'pnpm'
     
     - name: Install dependencies
-      run: npm ci
+      run: pnpm install
     
     - name: Run security audit
-      run: npm audit --audit-level moderate
+      run: pnpm audit --audit-level moderate
     
     - name: Check for vulnerabilities
-      run: npx audit-ci --moderate
+      run: pnpm exec audit-ci --moderate
 
   deploy-staging:
     runs-on: ubuntu-latest
@@ -93,21 +93,21 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20.x'
-        cache: 'npm'
+        cache: 'pnpm'
     
     - name: Install dependencies
-      run: npm ci
+      run: pnpm install
     
     - name: Initialize Stellar theme
       run: |
         git submodule update --init --recursive
-        npm run stellar:validate
+        pnpm run stellar:validate
     
     - name: Build for staging with Stellar theme
       run: |
-        npm run clean
+        pnpm run clean
         echo "🏗️ Building staging with Stellar theme..."
-        npm run build:staging || echo "⚠️ Build completed with warnings (json_ld helper errors are expected)"
+        pnpm run build:staging || echo "⚠️ Build completed with warnings (json_ld helper errors are expected)"
     
     - name: Verify Stellar build output
       run: |
@@ -147,21 +147,21 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20.x'
-        cache: 'npm'
+        cache: 'pnpm'
     
     - name: Install dependencies
-      run: npm ci
+      run: pnpm install
     
     - name: Initialize Stellar theme
       run: |
         git submodule update --init --recursive
-        npm run stellar:validate
+        pnpm run stellar:validate
     
     - name: Build for production with Stellar theme
       run: |
-        npm run clean
+        pnpm run clean
         echo "🏗️ Building production site with Stellar theme..."
-        npm run build || echo "⚠️ Build completed with warnings (json_ld helper errors are expected)"
+        pnpm run build || echo "⚠️ Build completed with warnings (json_ld helper errors are expected)"
         echo "📊 Production build statistics:"
         find public -name "*.html" | wc -l | xargs echo "Generated HTML files:"
         du -sh public | cut -f1 | xargs echo "Total size:"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,29 +29,29 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '22'
-        cache: 'npm'
+        cache: 'pnpm'
         
     - name: Install dependencies
-      run: npm ci
+      run: pnpm install
       
     - name: Initialize theme submodules
       run: |
         git submodule update --init --recursive
-        npm run themes:status
+        pnpm run themes:status
         
     - name: Validate Stellar theme configuration
-      run: npm run stellar:validate
+      run: pnpm run stellar:validate
       
     - name: Run tests (allow failures for now)
-      run: npm test || echo "⚠️ Tests failed but continuing with deployment"
+      run: pnpm test || echo "⚠️ Tests failed but continuing with deployment"
       
     - name: Build static files with Stellar theme
       run: |
-        npm run clean
+        pnpm run clean
         echo "🔍 Validating configuration before build..."
-        npm run stellar:validate
+        pnpm run stellar:validate
         echo "🏗️ Building with Stellar theme..."
-        npm run build
+        pnpm run build
         echo "📊 Build statistics:"
         find public -name "*.html" | wc -l | xargs echo "Generated HTML files:"
         du -sh public | cut -f1 | xargs echo "Total size:"

--- a/.github/workflows/incremental-deploy.yml
+++ b/.github/workflows/incremental-deploy.yml
@@ -30,15 +30,15 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '22'
-        cache: 'npm'
+        cache: 'pnpm'
         
     - name: Install dependencies
-      run: npm ci
+      run: pnpm install
       
     - name: Initialize theme submodules
       run: |
         git submodule update --init --recursive
-        npm run themes:status
+        pnpm run themes:status
         
     - name: Detect changed files in source directory
       id: changes
@@ -63,7 +63,7 @@ jobs:
       if: steps.changes.outputs.changed_files != 'none'
       run: |
         echo "🏗️ Building with Stellar theme (incremental mode)..."
-        npm run build
+        pnpm run build
         echo "📊 Build statistics:"
         find public -name "*.html" | wc -l | xargs echo "Generated HTML files:"
         du -sh public | cut -f1 | xargs echo "Total size:"

--- a/.github/workflows/stellar-ci.yml
+++ b/.github/workflows/stellar-ci.yml
@@ -22,27 +22,27 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '18'
-        cache: 'npm'
+        cache: 'pnpm'
         
     - name: Install dependencies
-      run: npm ci
+      run: pnpm install
       
     - name: Initialize submodules
       run: |
         git submodule update --init --recursive
         echo "📦 Theme submodules status:"
-        npm run themes:status
+        pnpm run themes:status
         
     - name: Validate Stellar theme configuration
       run: |
         echo "🔍 Running Stellar theme validation..."
-        npm run stellar:validate
+        pnpm run stellar:validate
         
     - name: Lint code
-      run: npm run lint
+      run: pnpm run lint
       
     - name: Run unit tests
-      run: npm test || echo "⚠️ Some tests failed"
+      run: pnpm test || echo "⚠️ Some tests failed"
 
   build-test:
     name: Build Test
@@ -60,10 +60,10 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '18'
-        cache: 'npm'
+        cache: 'pnpm'
         
     - name: Install dependencies
-      run: npm ci
+      run: pnpm install
       
     - name: Initialize submodules
       run: git submodule update --init --recursive
@@ -71,7 +71,7 @@ jobs:
     - name: Run Stellar test build
       run: |
         echo "🧪 Running Stellar theme test build..."
-        npm run stellar:test
+        pnpm run stellar:test
         
     - name: Verify build artifacts
       run: |
@@ -141,13 +141,13 @@ jobs:
         path: public/
         
     - name: Install Lighthouse CI
-      run: npm install -g @lhci/cli@0.12.x
+      run: pnpm add -g @lhci/cli@0.12.x
       
     - name: Run Lighthouse CI
       run: |
         echo "🔍 Running performance tests..."
         # 启动简单的HTTP服务器
-        npx http-server public -p 8080 &
+        pnpm dlx http-server public -p 8080 &
         sleep 5
         
         # 运行Lighthouse测试
@@ -164,7 +164,7 @@ jobs:
     - name: Run security audit
       run: |
         echo "🔒 Running security audit..."
-        npm audit --audit-level=moderate || echo "⚠️ Security audit completed with warnings"
+        pnpm audit --audit-level=moderate || echo "⚠️ Security audit completed with warnings"
         
     - name: Check for sensitive files
       run: |


### PR DESCRIPTION
## 问题描述

CI 工作流中使用了 npm，与项目声明的包管理器不一致。

## 解决方案

统一 CI 使用 pnpm 替代 npm：

```diff
- cache: 'npm'
+ cache: 'pnpm'

- npm ci
+ pnpm install

- npm run lint
+ pnpm run lint
```

## 修改的文件

- `.github/workflows/ci.yml`
- `.github/workflows/deploy.yml`
- `.github/workflows/incremental-deploy.yml`
- `.github/workflows/stellar-ci.yml`

## 验证

- [x] 语法检查通过
- [x] 与本地开发环境一致