### PR TITLE
fix: 统一 CI 分支名为 main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ main, develop ]
 
 jobs:
   test:
@@ -134,7 +134,7 @@ jobs:
   deploy-production:
     runs-on: ubuntu-latest
     needs: [test, security-scan]
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     
     steps:
     - name: Checkout code

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,11 +2,11 @@ name: Deploy Stellar Blog to GitHub Pages
 
 on:
   push:
-    branches: [ main, master, develop ]
+    branches: [ main, develop ]
     paths-ignore:
       - 'source/**'  # 忽略 source 目录，由 incremental-deploy 处理
   pull_request:
-    branches: [ main, master, develop ]
+    branches: [ main, develop ]
   # 支持手动触发（在 GitHub 仓库的 Actions 标签页手动运行）
   workflow_dispatch:
 
@@ -67,7 +67,7 @@ jobs:
         ls -la public/ | head -20
         
     - name: Deploy to GitHub Pages
-      if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/main')
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/incremental-deploy.yml
+++ b/.github/workflows/incremental-deploy.yml
@@ -2,7 +2,7 @@ name: Incremental Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ main, master ]  # 只在主分支触发
+    branches: [ main ]  # 只在 main 分支触发
     paths:
       - 'source/**'  # 只监听 source 目录下的变化
   workflow_dispatch:
@@ -78,7 +78,7 @@ jobs:
         echo "✅ Build verification passed"
         
     - name: Deploy to GitHub Pages (incremental)
-      if: steps.changes.outputs.changed_files != 'none' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+      if: steps.changes.outputs.changed_files != 'none' && github.event_name == 'push' && (github.ref == 'refs/heads/main')
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stellar-ci.yml
+++ b/.github/workflows/stellar-ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ develop ]
   pull_request:
-    branches: [ main, master, develop ]
+    branches: [ main, develop ]
 
 jobs:
   validate:


### PR DESCRIPTION
## 问题描述

CI 配置中混用了 master 和 main 分支名称，不一致。

## 解决方案

统一使用 main 作为默认/发布分支：

```diff
- branches: [ master, develop ]
+ branches: [ main, develop ]

- github.ref == 'refs/heads/master'
+ github.ref == 'refs/heads/main'
```

## 分支策略

- **main**: 默认/发布分支
- **develop**: 开发分支

## 修改的文件

- `.github/workflows/ci.yml`
- `.github/workflows/deploy.yml`
- `.github/workflows/incremental-deploy.yml`
- `.github/workflows/stellar-ci.yml`