### PR TITLE
fix(ci): 合并双部署、修复安全扫描与 PR 脚本注入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI/CD Pipeline
+name: CI
 
 on:
   push:
@@ -6,215 +6,78 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
-    
-    strategy:
-      matrix:
-        node-version: [20.x]
-    
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         submodules: true
         fetch-depth: 0
-    
+
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
       with:
         version: 10
 
-    - name: Setup Node.js ${{ matrix.node-version }}
+    - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: '20.x'
         cache: 'pnpm'
-    
+
     - name: Install dependencies
       run: pnpm install
-    
+
     - name: Initialize Stellar theme submodules
       run: |
         git submodule update --init --recursive
         pnpm run themes:status
-    
+
     - name: Validate Stellar theme configuration
       run: pnpm run stellar:validate
-    
+
     - name: Run tests
       run: pnpm test
-    
+
     - name: Lint check
       run: pnpm run lint
-    
+
     - name: Build test with Stellar theme
       run: |
         pnpm run clean
         pnpm run stellar:validate
-        echo "🏗️ Building with Stellar theme (json_ld errors are expected and don't affect final output)..."
-        pnpm run build || echo "⚠️ Build completed with warnings (json_ld helper errors are known and don't affect functionality)"
-    
+        pnpm run build
+
     - name: Check for broken links
-      run: pnpm run check-links || echo "⚠️ Link check completed with warnings"
+      run: pnpm run check-links || echo "::warning::Link check reported issues (non-blocking)"
 
   security-scan:
     runs-on: ubuntu-latest
     needs: test
-    
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
       with:
         version: 10
-    
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '20.x'
         cache: 'pnpm'
-    
+
     - name: Install dependencies
       run: pnpm install
-    
-    - name: Run security audit
-      run: |
-        # 使用官方 npm registry 进行 audit
-        pnpm config set registry https://registry.npmjs.org
-        pnpm audit --audit-level moderate || true
-    
-    - name: Check for vulnerabilities
+
+    - name: Run security audit (fail on high/critical)
       run: |
         pnpm config set registry https://registry.npmjs.org
-        pnpm exec audit-ci --moderate || true
-
-  deploy-staging:
-    runs-on: ubuntu-latest
-    needs: [test, security-scan]
-    if: github.ref == 'refs/heads/develop'
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        submodules: true
-        fetch-depth: 0
-    
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4
-      with:
-        version: 10
-    
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20.x'
-        cache: 'pnpm'
-    
-    - name: Install dependencies
-      run: pnpm install
-    
-    - name: Initialize Stellar theme
-      run: |
-        git submodule update --init --recursive
-        pnpm run stellar:validate
-    
-    - name: Build for staging with Stellar theme
-      run: |
-        pnpm run clean
-        echo "🏗️ Building staging with Stellar theme..."
-        pnpm run build:staging || echo "⚠️ Build completed with warnings (json_ld helper errors are expected)"
-    
-    - name: Verify Stellar build output
-      run: |
-        if [ ! -f "public/index.html" ]; then
-          echo "❌ Stellar build failed: index.html not found"
-          exit 1
-        fi
-        echo "✅ Stellar staging build verification passed"
-        echo "📊 Build statistics:"
-        find public -name "*.html" | wc -l | xargs echo "Generated HTML files:"
-        du -sh public | cut -f1 | xargs echo "Total size:"
-    
-    - name: Deploy to staging (GitHub Pages - staging)
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./public
-        publish_branch: gh-pages-staging
-        force_orphan: true
-        user_name: 'github-actions[bot]'
-        user_email: 'github-actions[bot]@users.noreply.github.com'
-        commit_message: 'deploy: Stellar theme staging - ${{ github.event.head_commit.message }}'
-
-  deploy-production:
-    runs-on: ubuntu-latest
-    needs: [test, security-scan]
-    if: github.ref == 'refs/heads/main'
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        submodules: true
-        fetch-depth: 0
-    
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4
-      with:
-        version: 10
-    
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20.x'
-        cache: 'pnpm'
-    
-    - name: Install dependencies
-      run: pnpm install
-    
-    - name: Initialize Stellar theme
-      run: |
-        git submodule update --init --recursive
-        pnpm run stellar:validate
-    
-    - name: Build for production with Stellar theme
-      run: |
-        pnpm run clean
-        echo "🏗️ Building production site with Stellar theme..."
-        pnpm run build || echo "⚠️ Build completed with warnings (json_ld helper errors are expected)"
-        echo "📊 Production build statistics:"
-        find public -name "*.html" | wc -l | xargs echo "Generated HTML files:"
-        du -sh public | cut -f1 | xargs echo "Total size:"
-    
-    - name: Verify Stellar production build
-      run: |
-        if [ ! -f "public/index.html" ]; then
-          echo "❌ Stellar production build failed: index.html not found"
-          exit 1
-        fi
-        
-        # 检查Stellar主题关键文件
-        echo "🔍 Verifying Stellar theme files:"
-        [ -f "public/css/main.css" ] && echo "  ✅ CSS files generated"
-        [ -f "public/js/main.js" ] && echo "  ✅ JS files generated"
-        [ -f "public/search.json" ] && echo "  ✅ Search index generated"
-        [ -f "public/sitemap.xml" ] && echo "  ✅ Sitemap generated"
-        [ -f "public/atom.xml" ] && echo "  ✅ RSS feed generated"
-        
-        echo "✅ Stellar production build verification passed"
-    
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./public
-        publish_branch: gh-pages
-        force_orphan: true
-        user_name: 'github-actions[bot]'
-        user_email: 'github-actions[bot]@users.noreply.github.com'
-        commit_message: 'deploy: Stellar theme production - ${{ github.event.head_commit.message }}'
+        pnpm exec audit-ci --high

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,99 +1,89 @@
-name: Deploy Stellar Blog to GitHub Pages
+name: Deploy
 
 on:
   push:
     branches: [ main, develop ]
-    paths-ignore:
-      - 'source/**'  # 忽略 source 目录，由 incremental-deploy 处理
-  pull_request:
-    branches: [ main, develop ]
-  # 支持手动触发（在 GitHub 仓库的 Actions 标签页手动运行）
   workflow_dispatch:
 
 permissions:
   contents: write
-  pages: write
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
-    - name: Checkout source code
-      uses: actions/checkout@v4
-      with:
-        submodules: true
-        fetch-depth: 0  # 获取完整历史，支持子模块
-        
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4
-      with:
-        version: 10
-        
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20.x'
-        cache: 'pnpm'
-        
-    - name: Install dependencies
-      run: pnpm install
-      
-    - name: Initialize theme submodules
-      run: |
-        git submodule update --init --recursive
-        pnpm run themes:status
-        
-    - name: Validate Stellar theme configuration
-      run: pnpm run stellar:validate
-      
-    - name: Run tests (allow failures for now)
-      run: pnpm test || echo "⚠️ Tests failed but continuing with deployment"
-      
-    - name: Build static files with Stellar theme
-      run: |
-        pnpm run clean
-        echo "🔍 Validating configuration before build..."
-        pnpm run stellar:validate
-        echo "🏗️ Building with Stellar theme..."
-        pnpm run build
-        echo "📊 Build statistics:"
-        find public -name "*.html" | wc -l | xargs echo "Generated HTML files:"
-        du -sh public | cut -f1 | xargs echo "Total size:"
-        
-    - name: Verify build output
-      run: |
-        if [ ! -f "public/index.html" ]; then
-          echo "❌ Build failed: index.html not found"
-          exit 1
-        fi
-        echo "✅ Build verification passed"
-        echo "📄 Generated files:"
-        ls -la public/ | head -20
-        
-    - name: Deploy to GitHub Pages
-      if: github.event_name == 'push' && (github.ref == 'refs/heads/main')
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./public
-        publish_branch: gh-pages
-        force_orphan: false
-        user_name: 'github-actions[bot]'
-        user_email: 'github-actions[bot]@users.noreply.github.com'
-        commit_message: 'deploy: Stellar theme - ${{ github.event.head_commit.message }}'
-        
-    - name: Notify deployment status
-      if: always()
-      run: |
-        if [ "${{ job.status }}" == "success" ]; then
-          echo "🎉 Stellar主题部署成功！"
-          echo "🌟 网站已更新到 GitHub Pages"
-          echo "🔗 访问地址: https://${{ github.repository_owner }}.github.io"
-        else
-          echo "❌ 部署失败，请检查构建日志"
-          echo "💡 常见问题："
-          echo "   - 检查Stellar主题配置"
-          echo "   - 验证子模块是否正确初始化"
-          echo "   - 确认所有依赖已安装"
-        fi
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Initialize theme submodules
+        run: |
+          git submodule update --init --recursive
+          pnpm run themes:status
+
+      - name: Validate Stellar theme configuration
+        run: pnpm run stellar:validate
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Build static files with Stellar theme
+        run: |
+          pnpm run clean
+          pnpm run stellar:validate
+          pnpm run build
+
+      - name: Verify build output
+        run: |
+          if [ ! -f "public/index.html" ]; then
+            echo "::error::Build failed: public/index.html not found"
+            exit 1
+          fi
+          echo "Build verification passed"
+          echo "Generated HTML files: $(find public -name '*.html' | wc -l)"
+          echo "Total size: $(du -sh public | cut -f1)"
+
+      - name: Deploy to GitHub Pages (staging)
+        if: github.ref == 'refs/heads/develop'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          publish_branch: gh-pages-staging
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'deploy: staging - ${{ github.event.head_commit.message }}'
+
+      - name: Deploy to GitHub Pages (production)
+        if: github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          publish_branch: gh-pages
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'deploy: production - ${{ github.event.head_commit.message }}'

--- a/.github/workflows/pr-compliance.yml
+++ b/.github/workflows/pr-compliance.yml
@@ -5,45 +5,47 @@ on:
     types: [opened, synchronize, edited]
     branches: [main, develop]
 
+permissions:
+  pull-requests: read
+
 jobs:
   pr-check:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          
-          # 检查格式: type(scope): subject
           if ! echo "$PR_TITLE" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9-]+\))?: .+'; then
-            echo "❌ PR 标题格式不正确"
-            echo ""
-            echo "正确格式: type(scope): subject"
-            echo "例如: feat(auth): 添加登录功能"
-            echo "      fix(contact): 修复渲染错误"
-            echo ""
-            echo "允许的 type:"
-            echo "  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert"
+            echo "::error::PR title format invalid"
+            echo "Correct format: type(scope): subject"
+            echo "Example: feat(auth): add login"
+            echo "Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert"
             exit 1
           fi
-          
-          echo "✅ PR 标题格式正确"
+          echo "PR title format OK"
 
       - name: Check PR description
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          BODY='${{ github.event.pull_request.body }}'
-          
-          if [ -z "$BODY" ] || [ ${#BODY} -lt 20 ]; then
-            echo "❌ PR 描述为空或过短"
-            echo "请填写 PR 描述模板"
+          if [ -z "$PR_BODY" ] || [ ${#PR_BODY} -lt 20 ]; then
+            echo "::error::PR description is empty or too short (min 20 chars)"
+            echo "Please fill in the PR description template"
             exit 1
           fi
-          
-          echo "✅ PR 描述已填写"
+          echo "PR description OK"
 
       - name: PR Info
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
         run: |
-          echo "📋 PR 信息:"
-          echo "   编号: #${{ github.event.pull_request.number }}"
-          echo "   标题: ${{ github.event.pull_request.title }}"
-          echo "   作者: ${{ github.event.pull_request.user.login }}"
-          echo "   分支: ${{ github.event.pull_request.head.ref }} → ${{ github.event.pull_request.base.ref }}"
+          echo "PR Info:"
+          echo "  Number: #$PR_NUMBER"
+          echo "  Title: $PR_TITLE"
+          echo "  Author: $PR_AUTHOR"
+          echo "  Branch: $PR_HEAD -> $PR_BASE"


### PR DESCRIPTION
## 概述

修复 #117 中记录的 GitHub Actions 问题。核心是把“测试/扫描”与“部署”职责理清，消除两套工作流往同一分支并发部署的竞态，并堵上安全扫描空操作和 PR 脚本注入。

## 改动

### `ci.yml`（只保留测试 + 安全扫描，移除部署）
- 删除 `deploy-staging` / `deploy-production` 两个 job —— 它们曾与 `deploy.yml` 并发往 `gh-pages`（及 `gh-pages-staging`）部署，互相覆盖（见 #117 第 1 条）。
- `security-scan` 去掉 `|| true`，改为 `pnpm exec audit-ci --high`，发现 high/critical 漏洞即失败（#117 第 2 条）。
- CI 构建去掉 `|| echo` 吞错，构建失败即失败，真正拦住坏构建（#117 第 3 条）。
- 链路检查 `check-links` 保留为非阻塞告警（用 `::warning::` 标注），因为外链偶发不可达属正常。
- 指定 `permissions: contents: read`。

### `deploy.yml`（统一承接 staging / production 部署）
- 新增 `concurrency` 串行控制，避免连续 push 时多实例同时推 `gh-pages`（#117 第 7 条）。
- develop → `gh-pages-staging`，main → `gh-pages`，两个部署目标收敛到这一个工作流。
- 移除指向不存在的 `incremental-deploy` 的 `paths-ignore`（#117 第 5 条）。
- 统一使用 `peaceiris/actions-gh-pages@v4`，并声明 `permissions: contents: write`。
- 部署前校验 `public/index.html`，缺失即失败。

### `pr-compliance.yml`（修复脚本注入）
- PR 标题/正文改为通过 `env:` 传入 step，不再直接插值进 shell（#117 第 4 条）。这是 GitHub 官方脚本注入的典型反模式，现用环境变量方式规避。

## ⚠️ 合并前请注意
- 由于 `security-scan` 现在会真的失败于 high/critical 漏洞，若依赖树当前存在此类漏洞，本 PR 的 CI 会显示红色。这是预期行为，建议同步升级/替换有漏洞的依赖。
- CI 构建现在是硬门禁。若 `json_ld` helper 的已知报错会导致 hexo 以非零退出，构建步骤会变红——需另行修复主题 helper，而非整段吞掉错误。
- 改动仅涉及 `.github/workflows/`，未触碰站点源码与子模块。

Closes #117
