### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync-cnb.yml
+++ b/.github/workflows/sync-cnb.yml
@@ -15,6 +15,9 @@ name: Sync to CNB
 # 注意：本仓库主分支在 CNB，正常情况下 .cnb.yml 已自动把 CNB 提交推回 GitHub，
 #       本 workflow 主要覆盖「直接改 GitHub 再回灌 CNB」的场景，为兜底方向。
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/h1s97x/H1S97X.github.io/security/code-scanning/1](https://github.com/h1s97x/H1S97X.github.io/security/code-scanning/1)

通用修复方式：在 workflow 根级（或具体 job 级）添加 `permissions`，明确声明最小必需权限，避免依赖仓库/组织默认设置。

本例最佳修复：在 `.github/workflows/sync-cnb.yml` 顶层 `on:` 之前（或之后）添加：
- `permissions:`
- `contents: read`

这不会改变现有同步逻辑：`actions/checkout` 读取仓库内容需要 `contents: read` 即可；对 CNB 的推送使用独立 secret，不依赖 GitHub 写权限。无需新增 import、方法或依赖。


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
